### PR TITLE
Export liquidParser to aid in defining new base languages for liquid.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/lang-liquid",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Liquid template support for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/src/liquid.ts
+++ b/src/liquid.ts
@@ -5,7 +5,7 @@ import {styleTags, tags as t} from "@lezer/highlight"
 import {parseMixed} from "@lezer/common"
 import {parser} from "./liquid.grammar"
 import {liquidCompletionSource, LiquidCompletionConfig} from "./complete"
-export {liquidCompletionSource, LiquidCompletionConfig}
+export {parser as liquidParser, liquidCompletionSource, LiquidCompletionConfig}
 
 function directiveIndent(except: RegExp) {
   return (context: TreeIndentContext) => {


### PR DESCRIPTION
As mentioned in my comment about supporting additional bases, I've added an export of the parser as `liquidParser` which I believe should provide everything needed in order to implement a new base.