### PR TITLE
Support multi-parameter filters

### DIFF
--- a/src/liquid.grammar
+++ b/src/liquid.grammar
@@ -39,7 +39,7 @@ directive {
 }
 
 @skip { space | InlineComment } {
-  Filter { "|" FilterName { identifier } (":" expression)? }
+  Filter { "|" FilterName { identifier } (":" expression ("," expression)*)? }
 
   VariableName { identifier }
   

--- a/test/test-liquid.ts
+++ b/test/test-liquid.ts
@@ -12,8 +12,14 @@ describe("Liquid parsing", () => {
   test("Interpolation", `One {{ page.title }}`,
        "Template(Text, Interpolation(MemberExpression(VariableName, PropertyName)))")
 
-  test("Filters", `{{ "adam!" | capitalize | prepend: "Hello " }}`,
-       "Template(Interpolation(StringLiteral, Filter(FilterName), Filter(FilterName, StringLiteral)))")
+  test("Filters", `{{ "adam!" | capitalize | prepend: "Hello " | replace: "Hello ", "Hi " }}`, `
+Template(
+  Interpolation(
+    StringLiteral,
+    Filter(FilterName),
+    Filter(FilterName, StringLiteral),
+    Filter(FilterName, StringLiteral, StringLiteral)))
+`)
 
   test("Unknown tag", "{% blah 88 %}",
        "Template(Tag(TagName, NumberLiteral))")


### PR DESCRIPTION
Support for multi-parameter liquid filters like `find: string, string`, `replace: string, string`, `color_mix: string, number`, etc.

Current implementation doesn't recognize multi-parameter filters.

Example:
`{{ "adam!" | capitalize | prepend: "Hello " | replace: "adam", "Adam" }}`